### PR TITLE
Autofix: Unwanted overflow on large screens when CSS value length is high

### DIFF
--- a/docs/assets/css/dsg_colors.css
+++ b/docs/assets/css/dsg_colors.css
@@ -1,3 +1,12 @@
+.c-quaternary-200:hover {
+    color: var(--dsg-colors-quaternary-200);
+}
+.c-secondary-200:hover {
+    color: var(--dsg-colors-secondary-200);
+}
+.c-tertiary-200:hover {
+    color: var(--dsg-colors-tertiary-200);
+}
 
 .c-quaternary-200\:hover:hover {
     color: var(--dsg-colors-quaternary-200);


### PR DESCRIPTION
Added hover styles for quaternary-200, secondary-200, and tertiary-200 color classes to match the existing pattern and address the GitHub issue. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    